### PR TITLE
Introduce backup fetch feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![YAML-lint status](https://github.com/aalaesar/backup_nextcloud/actions/workflows/yamllint.yml/badge.svg)](https://github.com/aalaesar/backup_nextcloud/actions?workflow=Yaml%20Lint)
 # backup_nextcloud
 
-An ansible role that creates a backup of a Nextcloud server. The backup is kept on the server.
+An ansible role that creates a backup of a Nextcloud server. The backup is kept on the server (unless you [fetch it](#fetching-backup-from-remote-to-local-machine)).
 
 ## Requirements
 
@@ -90,6 +90,15 @@ nextcloud_backup_user_files_versions: true
 nextcloud_backup_user_uploads: true
 nextcloud_backup_user_cache: true
 ```
+
+### Fetching backup from remote to local machine
+You can fetch created backup from remote by setting these variables.
+WARNING: user which you are used in Ansible has to be set as [backup owner](#adjusting-the-backup-owner) due to Ansible limitation on using `become` with `ansible.builtin.fetch`
+```yaml
+nextcloud_backup_fetch_to_local: true
+nextcloud_backup_fetch_local_path: "/local_path/nextcloud_backup"
+```
+
 ### Other
  You can leave the server in maintenance mode at the end of the process by turning false
  ```yaml

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,3 +31,7 @@ nextcloud_backup_user_cache: true
 
 ### DATABASE BACKUP ###
 nextcloud_backup_database: true
+
+### FETCH TO LOCAL MACHINE ###
+nextcloud_backup_fetch_to_local: false
+nextcloud_backup_fetch_local_path: "/tmp/nextcloud_backup"

--- a/tasks/fetching.yml
+++ b/tasks/fetching.yml
@@ -4,4 +4,3 @@
   ansible.builtin.fetch:
     src: "{{ nc_archive_path }}.{{ nextcloud_backup_format }}"
     dest: "{{ nextcloud_backup_fetch_local_path }}"
-  when: nextcloud_backup_fetch_to_local

--- a/tasks/fetching.yml
+++ b/tasks/fetching.yml
@@ -1,0 +1,7 @@
+---
+- name: Fetch file from remote to local
+  become: false # Using become may cause OOM errors. (https://docs.ansible.com/ansible/latest/collections/ansible/builtin/fetch_module.html#notes)
+  ansible.builtin.fetch:
+    src: "{{ nc_archive_path }}.{{ nextcloud_backup_format }}"
+    dest: "{{ nextcloud_backup_fetch_local_path }}"
+  when: nextcloud_backup_fetch_to_local

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,3 +36,6 @@
     - db_dump
 - name: Finish the backup
   ansible.legacy.import_tasks: finishing.yml
+- name: Fetch backup to local
+  ansible.legacy.import_tasks: fetching.yml
+  when: nextcloud_backup_fetch_to_local


### PR DESCRIPTION
Hi! I've added feature to download created backup from remote to local host. It enables user to turn it on/off and define path where to save downloaded file on local machine.
There is one caveat here, Ansible user has to be the owner of backup directory, because of known `fetch` limitations while using `become`.
I've also added README entry, how to set it properly.
@aalaesar please take a look :)