### PR TITLE
Add switch for downloading Nextcloud-server archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ nextcloud_backup_database: true
 ```
 
 ### Adjusting nextcloud-server archive included in backup
-Role will download the proper server archive from the nextcloud download site by default. It can be turned off using: `nextcloud_backup_download_server_archive` variable.
+Role can download the proper server archive from the nextcloud download site and add it to backup archive. 
+It can be turned on using: `nextcloud_backup_download_server_archive` variable.
 
 ### Adjusting app data backup
 

--- a/README.md
+++ b/README.md
@@ -55,15 +55,18 @@ nc_archive_name: "{{ nextcloud_instance_name }}_nextcloud-{{ nc_status.versionst
 The role will __always__:
  - backup the server's config
  - create a list of installed & enabled applications(along with the version numbers)
- - download the proper server archive from the nextcloud download site.
 
 You can adjust the scope of the backup by enabling/disabling some flags defined in default:
 
 ```yaml
+nextcloud_backup_download_server_archive: true
 nextcloud_backup_app_data: true
 nextcloud_backup_user: true
 nextcloud_backup_database: true
 ```
+
+### Adjusting nextcloud-server archive included in backup
+Role will download the proper server archive from the nextcloud download site by default. It can be turned off using: `nextcloud_backup_download_server_archive` variable.
 
 ### Adjusting app data backup
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,6 +16,9 @@ nextcloud_backup_file_mode: "0640"
 nextcloud_backup_dir_mode: "0750"
 nextcloud_backup_format: "tgz"
 
+### NEXTCLOUD SERVER ARCHIVE DOWNLOAD ###
+nextcloud_backup_download_server_archive: true
+
 ### APPS BACKUPS ###
 nextcloud_backup_app_data: true
 nextcloud_backup_app_data_exclude_folder:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,7 +17,7 @@ nextcloud_backup_dir_mode: "0750"
 nextcloud_backup_format: "tgz"
 
 ### NEXTCLOUD SERVER ARCHIVE DOWNLOAD ###
-nextcloud_backup_download_server_archive: true
+nextcloud_backup_download_server_archive: false
 
 ### APPS BACKUPS ###
 nextcloud_backup_app_data: true

--- a/tasks/files.yml
+++ b/tasks/files.yml
@@ -30,6 +30,7 @@
     owner: "{{ nextcloud_backup_owner }}"
     group: "{{ nextcloud_backup_group }}"
     mode: "{{ nextcloud_backup_file_mode }}"
+  when: nextcloud_backup_download_server_archive
 
 - name: Export the list of apps in the backup
   ansible.builtin.copy:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,7 +29,7 @@
 - name: Run applications backups
   ansible.legacy.import_tasks: app_data.yml
   when: nextcloud_backup_user
-- name: Run batabase backup
+- name: Run database backup
   ansible.legacy.import_tasks: database.yml
   when: nextcloud_backup_database
   tags:


### PR DESCRIPTION
Hello @aalaesar! 
I've added a switch (default `true` for backward compatibility) to adjust downloading of nextcloud-server archive.
Adding it to archive every single time, while running backup job is not mandatory in all cases. In my it took quite a long time and then increased `tar` archive size (~200MB).